### PR TITLE
Oscar/jwt util key store

### DIFF
--- a/pkg/jwt_util/token.go
+++ b/pkg/jwt_util/token.go
@@ -43,7 +43,7 @@ func (j *jwtUtil) createToken(claims map[string]interface{}) (string, map[string
 	j.injectStandardClaims(claims)
 	token := jwt.NewWithClaims(jwt.SigningMethodPS256, jwt.MapClaims(claims))
 
-	signingKey, err := keys.GetInMemoryRsaKeyPair().GetSigningKey()
+	signingKey, err := keys.GetInMemoryRsaKeyStore().GetSigningKey()
 	tokenString, err := token.SignedString(signingKey)
 	if err != nil {
 		return "", nil, err
@@ -54,7 +54,7 @@ func (j *jwtUtil) createToken(claims map[string]interface{}) (string, map[string
 
 func (j *jwtUtil) DecodeToken(tokenType TokenType, tokenString string) (map[string]interface{}, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		return keys.GetInMemoryRsaKeyPair().GetVerificationKey()
+		return keys.GetInMemoryRsaKeyStore().GetVerificationKey()
 	})
 
 	if err != nil {

--- a/pkg/keys/keys_test/rsa_test.go
+++ b/pkg/keys/keys_test/rsa_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestGetInMemoryRsaKeyPair_Singleton(t *testing.T) {
-	keyPair1 := keys.GetInMemoryRsaKeyPair()
-	keyPair2 := keys.GetInMemoryRsaKeyPair()
+	keyPair1 := keys.GetInMemoryRsaKeyStore()
+	keyPair2 := keys.GetInMemoryRsaKeyStore()
 
-	assert.Equal(t, keyPair1, keyPair2, "GetInMemoryRsaKeyPair should always return the same instance")
+	assert.Equal(t, keyPair1, keyPair2, "GetInMemoryRsaKeyStore should always return the same instance")
 }
 
 func TestInMemoryRsaKeyPair_GetVerificationKey(t *testing.T) {
-	keyPair := keys.GetInMemoryRsaKeyPair()
+	keyPair := keys.GetInMemoryRsaKeyStore()
 
 	verificationKey1, err1 := keyPair.GetVerificationKey()
 	assert.Nil(t, err1, "GetVerificationKey should not return an error")
@@ -26,7 +26,7 @@ func TestInMemoryRsaKeyPair_GetVerificationKey(t *testing.T) {
 }
 
 func TestInMemoryRsaKeyPair_GetSigningKey(t *testing.T) {
-	keyPair := keys.GetInMemoryRsaKeyPair()
+	keyPair := keys.GetInMemoryRsaKeyStore()
 
 	signingKey1, err1 := keyPair.GetSigningKey()
 	assert.Nil(t, err1, "GetSigningKey should not return an error")

--- a/pkg/keys/rsa.go
+++ b/pkg/keys/rsa.go
@@ -6,26 +6,28 @@ import (
 	"fmt"
 )
 
-type RsaKeyPair interface {
+type RsaKeyStore interface {
 	GetVerificationKey() (*rsa.PublicKey, error)
 	GetSigningKey() (*rsa.PrivateKey, error)
 }
 
-type inMemoryRsaKeyPair struct {
+// In-memory RSA key store, for monolithic deployment and development.
+// RSA key pair is generated on first access and kept only in memory.
+type inMemoryRsaKeyStore struct {
 	signingKey      *rsa.PrivateKey
 	verificationKey *rsa.PublicKey
 }
 
-var inMemoryRsaKeyPairInstance *inMemoryRsaKeyPair
+var inMemoryRsaKeyStoreInstance *inMemoryRsaKeyStore
 
-func GetInMemoryRsaKeyPair() RsaKeyPair {
-	if inMemoryRsaKeyPairInstance == nil {
-		inMemoryRsaKeyPairInstance = &inMemoryRsaKeyPair{}
+func GetInMemoryRsaKeyStore() RsaKeyStore {
+	if inMemoryRsaKeyStoreInstance == nil {
+		inMemoryRsaKeyStoreInstance = &inMemoryRsaKeyStore{}
 	}
-	return inMemoryRsaKeyPairInstance
+	return inMemoryRsaKeyStoreInstance
 }
 
-func (keyPair *inMemoryRsaKeyPair) makeKeyPair() (*rsa.PrivateKey, *rsa.PublicKey, error) {
+func (keyPair *inMemoryRsaKeyStore) makeKeyPair() (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		fmt.Println(fmt.Sprintf("Failed to create private key: %s", err))
@@ -39,7 +41,7 @@ func (keyPair *inMemoryRsaKeyPair) makeKeyPair() (*rsa.PrivateKey, *rsa.PublicKe
 	return signingKey, verificationKey, nil
 }
 
-func (keyPair *inMemoryRsaKeyPair) GetVerificationKey() (*rsa.PublicKey, error) {
+func (keyPair *inMemoryRsaKeyStore) GetVerificationKey() (*rsa.PublicKey, error) {
 	if keyPair.verificationKey == nil {
 		_, _, err := keyPair.makeKeyPair()
 		if err != nil {
@@ -50,7 +52,7 @@ func (keyPair *inMemoryRsaKeyPair) GetVerificationKey() (*rsa.PublicKey, error) 
 	return keyPair.verificationKey, nil
 }
 
-func (keyPair *inMemoryRsaKeyPair) GetSigningKey() (*rsa.PrivateKey, error) {
+func (keyPair *inMemoryRsaKeyStore) GetSigningKey() (*rsa.PrivateKey, error) {
 	if keyPair.signingKey == nil {
 		_, _, err := keyPair.makeKeyPair()
 		if err != nil {


### PR DESCRIPTION
- Rename `RsaKeyPair` to `RsaKeyStore` (both for the struct and interface)
- Refactor the `JwtUtil` struct to have a member `KeyStore` which implements the `RsaKeyStore` interface.

So we can implement different RsaKeyStores (such as Cloud based or file based key stores) in future, and as long as they implement the `RsaKeyStore` interface, they can be used by the `JwtUtil` the same way.